### PR TITLE
Fixing static folder issue on windows (clock)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "A starting point for web apps based on the actor model",
   "scripts": {
-    "copy-static": "cpx 'static/**' dist",
+    "copy-static": "cpx static/** dist",
     "gzip": "gzip -k9nr dist",
     "build": "rollup -c && npm run copy-static && npm run gzip",
     "serve": "http-server dist -c0 -g"


### PR DESCRIPTION
As discussed on #5, single quotes are not interpreted by the windows command line. Therefore, either replacing them with double quotes or removing them can be a solution.
Since the path doesn't contain any withe space, I'm just removing them.