### PR TITLE
Fixing static folder issue on windows (reddit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "actor-helpers": "git+https://github.com/PolymerLabs/actor-helpers.git#master"
   },
   "scripts": {
-    "copy-static": "cpx 'static/**/*' dist/",
+    "copy-static": "cpx static/** dist/",
     "build": "rollup -c && npm run copy-static",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
     "format": "cd ../../ && npm run format",


### PR DESCRIPTION
As discussed on #5, single quotes are not interpreted by the windows command line. Therefore, either replacing them with double quotes or removing them can be a solution.
Since the path doesn't contain any withe space, I'm just removing them.

Same fix as #6 but for the *demo-reddit* branch.